### PR TITLE
kaminari gemをインストールしてほんの一覧にページネーションを追加した

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -81,3 +81,5 @@ group :test do
 end
 
 gem 'carrierwave'
+
+gem 'kaminari'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -131,6 +131,18 @@ GEM
       actionview (>= 5.0.0)
       activesupport (>= 5.0.0)
     json (2.6.3)
+    kaminari (1.2.2)
+      activesupport (>= 4.1.0)
+      kaminari-actionview (= 1.2.2)
+      kaminari-activerecord (= 1.2.2)
+      kaminari-core (= 1.2.2)
+    kaminari-actionview (1.2.2)
+      actionview
+      kaminari-core (= 1.2.2)
+    kaminari-activerecord (1.2.2)
+      activerecord
+      kaminari-core (= 1.2.2)
+    kaminari-core (1.2.2)
     loofah (2.21.3)
       crass (~> 1.0.2)
       nokogiri (>= 1.12.0)
@@ -282,6 +294,7 @@ DEPENDENCIES
   i18n_generators
   importmap-rails
   jbuilder
+  kaminari
   puma
   rails (~> 7.0.6)
   rubocop (~> 1.45.1)

--- a/app/controllers/books_controller.rb
+++ b/app/controllers/books_controller.rb
@@ -5,7 +5,7 @@ class BooksController < ApplicationController
 
   # GET /books or /books.json
   def index
-    @books = Book.all
+    @books = Book.order(id: :desc).page params[:page]
   end
 
   # GET /books/1 or /books/1.json

--- a/app/views/books/index.html.erb
+++ b/app/views/books/index.html.erb
@@ -14,5 +14,6 @@
 </div>
 
 <nav class="page-nav">
+  <%= paginate @books %>
   <%= link_to t('views.common.new', name: Book.model_name.human.downcase), new_book_path %>
 </nav>

--- a/config/initializers/kaminari_config.rb
+++ b/config/initializers/kaminari_config.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+Kaminari.configure do |config|
+  # config.default_per_page = 25
+  # config.max_per_page = nil
+  # config.window = 4
+  # config.outer_window = 0
+  # config.left = 0
+  # config.right = 0
+  # config.page_method_name = :page
+  # config.param_name = :page
+  # config.max_pages = nil
+  # config.params_on_first_page = false
+end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -152,6 +152,14 @@ en:
       create: Create %{model}
       submit: Save %{model}
       update: Update %{model}
+    page_entries_info:
+      one_page:
+        display_entries:
+          zero: "No %{entry_name} found"
+          one: "Displaying <b>1</b> %{entry_name}"
+          other: "Displaying <b>all %{count}</b> %{entry_name}"
+      more_pages:
+        display_entries: "Displaying %{entry_name} <b>%{first}–%{last}</b> of <b>%{total}</b> in total"
   number:
     currency:
       format:
@@ -228,6 +236,12 @@ en:
       title_edit: "Editing %{name}"
       error: error
       validation_error: "%{errors} prohibited this %{name} from being saved"
+    pagination:
+      first: "&laquo; First"
+      last: "Last &raquo;"
+      previous: "&lsaquo; Prev"
+      next: "Next &rsaquo;"
+      truncate: "&hellip;"
   controllers:
     common:
       notice_create: "%{name} was successfully created."

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -120,6 +120,14 @@ ja:
       create: 登録する
       submit: 保存する
       update: 更新する
+    page_entries_info:
+      more_pages:
+        display_entries: "<b>%{total}</b>中の%{entry_name}を表示しています <b>%{first} - %{last}</b>"
+      one_page:
+        display_entries:
+          one: "<b>%{count}</b>レコード表示中です %{entry_name}"
+          other: "<b>%{count}</b>レコード表示中です %{entry_name}"
+          zero: "レコードが見つかりませんでした %{entry_name}"
   number:
     currency:
       format:
@@ -194,6 +202,12 @@ ja:
       title_edit: "%{name}の編集"
       error: エラー
       validation_error: "%{errors}があるため、この%{name}は保存できませんでした"
+    pagination:
+      first: "&laquo; 最初"
+      last: "最後 &raquo;"
+      next: "次 &rsaquo;"
+      previous: "&lsaquo; 前"
+      truncate: "&hellip;"
   controllers:
     common:
       notice_create: "%{name}が作成されました。"


### PR DESCRIPTION
## 背景
- プラクティス「kaminari を使ってページング処理を実装する」として本の一覧ページにページネーションを追加したい

## やったこと
- [x] kaminari gemをインストールした
- [x] ページネーション関連のi18nを追加した
- [x] 本の一覧にページネーションを追加した
  - [x] orderはid降順

## スクリーンショット
- 本の一覧ページ
  - ![CleanShot 2024-10-21 at 14 13 50@2x](https://github.com/user-attachments/assets/0ad38a1e-c654-4072-9b9e-310e028c6129)
  - ![CleanShot 2024-10-21 at 14 14 05@2x](https://github.com/user-attachments/assets/8cbb7f2c-f494-4a8e-9fed-f3b6fe46ab27)
- rubocop、erblintの結果
  - ![CleanShot 2024-10-21 at 14 17 06@2x](https://github.com/user-attachments/assets/a37cf83d-d254-430b-a324-b237f6c6dc8c)
